### PR TITLE
Improve coordinate extraction

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -53,18 +53,10 @@ app.post('/api/gpx', async (req, res) => {
     let coords = await extractRouteData(page);
     await browser.close();
 
-    // Nur plausible Geo-Punkte behalten und ggf. Lat/Lon tauschen
-    coords = coords
-        .map(([a, b]) => {
-            if (Math.abs(a) <= 90 && Math.abs(b) <= 180) {
-                return [a, b];
-            }
-            if (Math.abs(b) <= 90 && Math.abs(a) <= 180) {
-                return [b, a];
-            }
-            return null;
-        })
-        .filter(Boolean);
+    // Erste doppelte Koordinaten (Start/Ziel in Metadaten) entfernen
+    if (coords.length > 4) {
+      coords = coords.slice(4);
+    }
 
     // Doppelte aufeinanderfolgende Punkte entfernen
     coords = coords.filter(


### PR DESCRIPTION
## Summary
- refine parser to grab coordinates only from directions payload
- discard initial metadata duplicates and remove sequential duplicates

## Testing
- `node -c parse.js`
- `node -c index.js`


------
https://chatgpt.com/codex/tasks/task_e_68585c5dafd08325b52eb57c8964abd1